### PR TITLE
Add troubleshoot to install ImageMagick in Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ bundle exec shotgun
 Then open [http://localhost:9393/api/v1.png?values=1,4,5,3,2,5](http://localhost:9393/api/v1.png?values=1,4,5,3,2,5).
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+## Troubleshooting
+
+For Ubuntu (and other [Linux variants](http://stackoverflow.com/a/16775397/1476898)), the development packages are required in addition to the binaries for ImageMagick.                                                                                                        
+ ```bash                                                                         
+ apt-get install libmagickwand-dev imagemagick                                   
+ ```                


### PR DESCRIPTION
The error I encountered when `bundle install` is the following:
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.