### PR TITLE
Add fixed width functionality to option parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ parameter | default | unit | purpose
 `height` | `30` | pixels | height of image
 `line_color` | `4A8FED` | hex | color of line
 `step` | `30` | pixels | distance between steps
-`width` | | pixels | total graph (overides step distance)
+`width` | | pixels | width of total graph (overides step distance)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ parameter | default | unit | purpose
 `height` | `30` | pixels | height of image
 `line_color` | `4A8FED` | hex | color of line
 `step` | `30` | pixels | distance between steps
-`width` | | pixels | width of total graph (overides step distance)
+`width` | | pixels | fixed width of total graph (overides step distance)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ parameter | default | unit | purpose
 `height` | `30` | pixels | height of image
 `line_color` | `4A8FED` | hex | color of line
 `step` | `30` | pixels | distance between steps
+`width` | | pixels | total graph (overides step distance)
 
 Example:
 

--- a/server.rb
+++ b/server.rb
@@ -7,6 +7,14 @@ def param_with_default(key, default)
   params[key] ? params[key] : default
 end
 
+def width_with_default(default, val_length)
+  if params[:width]
+    params[:width].to_i / val_length
+  else
+    default/val_length
+  end
+end
+
 def fixnum_param_with_default(key, default)
   param_with_default(key, default).to_i
 end
@@ -15,14 +23,15 @@ def generate_image(file_type)
   values = params[:values].split(',').map(&:to_f)
   background_color = param_with_default(:background_color, 'FFFFFF')
   line_color = param_with_default(:line_color, '4A8FED')
-
+  step_width = width_with_default(200, values.length)
   # http://bit.ly/1qnR55Y
   blob = Sparklines.plot(values,
     background_color: "##{background_color}",
     dot_size: fixnum_param_with_default(:dot_size, 4),
     height: fixnum_param_with_default(:height, 30),
+
     line_color: "##{line_color}",
-    step: fixnum_param_with_default(:step, 30)
+    step: step_width
   )
 
   content_type file_type

--- a/server.rb
+++ b/server.rb
@@ -7,7 +7,7 @@ def param_with_default(key, default)
   params[key] ? params[key] : default
 end
 
-def width_with_default( val_length)
+def width_with_default(val_length)
   if params[:width]
     params[:width].to_i / (val_length - 1)
   else

--- a/server.rb
+++ b/server.rb
@@ -11,7 +11,7 @@ def width_with_default( val_length)
   if params[:width]
     params[:width].to_i / (val_length - 1)
   else
-    nil
+    fixnum_param_with_default(:step, 30)
   end
 end
 
@@ -23,7 +23,7 @@ def generate_image(file_type)
   values = params[:values].split(',').map(&:to_f)
   background_color = param_with_default(:background_color, 'FFFFFF')
   line_color = param_with_default(:line_color, '4A8FED')
-  step_width = width_with_default(values.length) || fixnum_param_with_default(:step, 30)
+  step_width = width_with_default(values.length)
   # http://bit.ly/1qnR55Y
   blob = Sparklines.plot(values,
     background_color: "##{background_color}",

--- a/server.rb
+++ b/server.rb
@@ -7,11 +7,11 @@ def param_with_default(key, default)
   params[key] ? params[key] : default
 end
 
-def width_with_default(default, val_length)
+def width_with_default( val_length)
   if params[:width]
-    params[:width].to_i / val_length
+    params[:width].to_i / (val_length - 1)
   else
-    default/val_length
+    nil
   end
 end
 
@@ -23,7 +23,7 @@ def generate_image(file_type)
   values = params[:values].split(',').map(&:to_f)
   background_color = param_with_default(:background_color, 'FFFFFF')
   line_color = param_with_default(:line_color, '4A8FED')
-  step_width = width_with_default(200, values.length)
+  step_width = width_with_default(values.length) || fixnum_param_with_default(:step, 30)
   # http://bit.ly/1qnR55Y
   blob = Sparklines.plot(values,
     background_color: "##{background_color}",


### PR DESCRIPTION
Users of this application can also set a fixed image width instead of setting a step distance.  The fixed width overrides step parameters/default values and sets an average step distance for each point .