### PR TITLE
Add link to sparkline page on Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sparkle
 
-API for generating sparklines as images.
+API for generating [sparklines](https://en.wikipedia.org/wiki/Sparkline) as images.
 
 ## Usage
 


### PR DESCRIPTION
Why:

* Some people don't know what a sparkline is.

This change addresses the need by:

* Adds link to sparkline page on wikipedia on README.